### PR TITLE
Updates `npm run dev` command to include env vars defined in `.env` for use in custom server.js file

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,1 @@
+SECRET_KEY=abc123

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 
 ## Development
 
-Run the Express server with Vite dev middleware:
+1. Copy `.env.template` to create `.env` file & populate with correct values
 
-```shellscript
-npm run dev
-```
+2. Run the Express server with Vite dev middleware:
+   ```shellscript
+   npm run dev
+   ```
 
 ## Deployment
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "remix vite:build",
-    "dev": "node ./server.js",
+    "dev": "cross-env NODE_ENV=development node --require ./node_modules/dotenv/config ./server.js",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "cross-env NODE_ENV=production node ./server.js",
     "typecheck": "tsc"


### PR DESCRIPTION
The Remix compiler's `remix dev` command has some automagic that is lost when using Vite + custom server.

`remix dev`
* sets `NODE_ENV` to `development` [source](https://github.com/remix-run/remix/blob/main/packages/remix-dev/cli/commands.ts#L201)
* includes `dotenv` support, so `process.env.<ENV_VAR_KEY>` can be used in _server.js_
	1. [dev](https://github.com/remix-run/remix/blob/main/packages/remix-dev/cli/commands.ts#L186) command calls
	2. [devServer_unstable.serve](https://github.com/remix-run/remix/blob/8f6e21f0a740b245d5283090a42c2b7542720245/packages/remix-dev/devServer_unstable/index.ts#L43) which calls
	3. [loadEnv](https://github.com/remix-run/remix/blob/8f6e21f0a740b245d5283090a42c2b7542720245/packages/remix-dev/devServer_unstable/index.ts#L54) which
	4. [includes _dotenv_](https://github.com/remix-run/remix/blob/8f6e21f0a740b245d5283090a42c2b7542720245/packages/remix-dev/devServer_unstable/env.ts#L9) with the _.env_ file

---

The `vite-express` template has the `dev` command as simply: `node ./server.js`.

Remix has added support so `.server` code within the `app` directory has access to `NODE_ENV` as `development` and any ENV VARS defined in a `.env` file.

However, the custom server file (_server.js_) lives outside the app directory & all values for `process.env.<ENV_VAR_KEY>` are `undefined`.

This PR updates the `dev` command, so that the `server.js` file will also have access to the `process.env.<ENV_VAR_KEY>` values.

<img width="633" alt="Screenshot 2024-03-16 at 10 31 41 PM" src="https://github.com/kaylah/remix-vite-express-typescript/assets/1417250/352545dc-a38e-4490-be19-b8160fc29a4e">

1. `npm run dev:og` shows env var values in _server.js_ file with `node ./server.js`

5. `npm run dev` shows env var values in _server.js_ file with the update in this PR
